### PR TITLE
fix test_unit_generate_configuration

### DIFF
--- a/tests/test_unit_generate_configuration.py
+++ b/tests/test_unit_generate_configuration.py
@@ -26,10 +26,8 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.generator.scripts, None)
         self.assertEqual(self.generator.additional_scripts, None)
         self.assertEqual(self.generator.without_sources, False)
-        self.assertEqual(self.generator.dist_git, False)
         # Set to True in the configure() method later 
         self.assertEqual(self.generator.ssl_verify, None)
-        self.assertFalse(self.generator.dist_git)
 
     def test_fail_if_version_mismatch(self):
         with self.descriptor as f:


### PR DESCRIPTION
These tests broke when the dist_git functionality was broken out
to a plugin.

(Separately TODO: write a test for the dist_git plugin.)
